### PR TITLE
Add 'objectEquality' params to watcher to enable watch on array (pop and shift)

### DIFF
--- a/angular-peity.js
+++ b/angular-peity.js
@@ -39,7 +39,7 @@ var buildChartDirective = function(chartType) {
       var watcher = scope.$watch('data', function(){
         span.textContent = scope.data.join();
         jQuery( span ).change();
-      });
+      }, true);
 
       scope.$on('$destroy', function(){
         watcher();


### PR DESCRIPTION
Fixes #5 

Just added a simple params to `$watcher`, and now the watcher will be triggered when pushing , poping or shifting the array.



